### PR TITLE
Add support for GHES API endpoint

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,6 +38,7 @@ jobs:
           minimum_coverage: 80
           fail_below_threshold: false
           publish_only_summary: false
+          ghes_api_endpoint: ${{ secrets.GHES_API_ENDPOINT }}
       
       # Publish Coverage Job Summary  # Optional
       - name: Add Jacocoo report to workflow run summary
@@ -72,6 +73,7 @@ This Action defines the following formal inputs.
 |**`fail_below_threshold`** | false | Set True to fail the action and False to let it pass.
 |**`skip_check_run`** | false | If true, will skip attaching the Coverage Result report to the Workflow Run using a Check Run. Useful if your report has 65k characters that is not accepted by Github REST and GraphQL APIs
 |**`publish_only_summary`** | false | If true, will publish only a summary table of the Coverage Result report to the Workflow Run using a Check Run. Useful if your full coverage report has 65k characters that is not accepted by Github REST and GraphQL APIs
+|**`ghes_api_endpoint`** | false | The GHES API endpoint to use when running on GitHub Enterprise Server. If not provided, the default GitHub cloud API endpoint will be used.
 
 ### Outputs
 

--- a/action.ps1
+++ b/action.ps1
@@ -31,6 +31,7 @@ $inputs = @{
     minimum_coverage      = Get-ActionInput minimum_coverage
     fail_below_threshold  = Get-ActionInput fail_below_threshold
     publish_only_summary  = Get-ActionInput publish_only_summary
+    ghes_api_endpoint     = Get-ActionInput ghes_api_endpoint
 }
 
 $test_results_dir = Join-Path $PWD _TMP
@@ -316,6 +317,9 @@ function Publish-ToCheckRun {
 
     Write-ActionInfo "Adding Check Run"
     $url = "https://api.github.com/repos/$repoFullName/check-runs"
+    if ($inputs.ghes_api_endpoint) {
+        $url = "$($inputs.ghes_api_endpoint)/repos/$repoFullName/check-runs"
+    }
     $hdr = @{
         Accept = 'application/vnd.github+json'
         Authorization = "token $ghToken"

--- a/action.yml
+++ b/action.yml
@@ -1,4 +1,3 @@
-
 ## This is a SAMPLE metadata file for a GitHub Action.  For more info:
 ##    https://help.github.com/en/articles/metadata-syntax-for-github-actions
 
@@ -76,6 +75,12 @@ inputs:
       If true, will skip attaching the Tests Result report to the 
       Workflow Run using a Check Run. Useful if your report has 65k 
       characters that is not accepted by Github REST and GraphQL APIs
+    required: false
+
+  ghes_api_endpoint:
+    description: |
+      The GHES API endpoint to use when running on GitHub Enterprise Server.
+      If not provided, the default GitHub cloud API endpoint will be used.
     required: false
 
 ## Here you describe your *formal* outputs.


### PR DESCRIPTION
Related to #70

Add support for GHES API endpoint configuration.

* Add a new input parameter `ghes_api_endpoint` in `action.yml` to specify the GHES API endpoint.
* Update `action.ps1` to use the `ghes_api_endpoint` if provided, otherwise default to GitHub cloud API.
* Update the documentation in `README.md` to include the new `ghes_api_endpoint` input parameter.

---

For more details, open the [Copilot Workspace session](https://copilot-workspace.githubnext.com/PavanMudigonda/jacoco-reporter/issues/70?shareId=XXXX-XXXX-XXXX-XXXX).